### PR TITLE
feat: adicionando o baseline multihead attention

### DIFF
--- a/src/gpt_2/__init__.py
+++ b/src/gpt_2/__init__.py
@@ -1,1 +1,1 @@
-from .model import GPT2ModelGQA
+from .model import GPT2ModelGQA, GPT2ModelMHA

--- a/src/gpt_2/model.py
+++ b/src/gpt_2/model.py
@@ -55,6 +55,54 @@ class GroupedQueryAttention(torch.nn.Module):
 
         return concat
 
+class MultiHeadAttention(torch.nn.Module):
+    def __init__(self, dim_in, dim_out, context_length, num_heads, bias=False):
+        super().__init__()
+
+        self.dim_out = dim_out
+        self.num_heads = num_heads
+        self.head_dim = dim_out // num_heads
+
+        assert dim_out % num_heads == 0
+
+        self.wq = torch.nn.Linear(dim_in, dim_out, bias=bias)
+        self.wk = torch.nn.Linear(dim_in, dim_out, bias=bias) 
+        self.wv = torch.nn.Linear(dim_in, dim_out, bias=bias) 
+        self.wo_proj = torch.nn.Linear(dim_out, dim_out, bias=bias)
+
+        self.register_buffer(
+            "mask",
+            torch.triu(torch.ones(context_length, context_length), diagonal=1)
+        )
+
+    def forward(self, x):
+        batch, num_tokens, d_in = x.shape
+        queries = self.wq(x)
+        keys = self.wk(x)
+        values = self.wv(x)
+
+        queries = queries.view(batch, num_tokens, self.num_heads, self.head_dim)
+        keys = keys.view(batch, num_tokens, self.num_heads, self.head_dim) 
+        values = values.view(batch, num_tokens, self.num_heads, self.head_dim) 
+
+        queries = queries.transpose(1, 2)
+        keys = keys.transpose(1, 2)  
+        values = values.transpose(1, 2) 
+
+        attention = queries @ keys.transpose(2, 3)
+        attention.masked_fill_(
+            self.mask.bool()[:num_tokens, :num_tokens],
+            -torch.inf
+        )
+        causal_attention = torch.softmax(attention / keys.shape[-1]**0.5, dim=-1)
+        
+        context_vec = causal_attention @ values
+        context_vec = context_vec.transpose(1, 2)
+
+        concat = context_vec.contiguous().view(batch, num_tokens, self.dim_out)
+        concat = self.wo_proj(concat)
+
+        return concat
 
 class LayerNorm(torch.nn.Module):
     def __init__(self, embedding_dim, epsilon = 1e-5):
@@ -140,6 +188,39 @@ class TransformerBlockGQA(torch.nn.Module):
         add2 = forward + residual_connetion_forward
 
         return add2
+    
+    
+class TransformerBlockMHA(torch.nn.Module):
+    def __init__(self, context_length, dim_in, dim_out, num_heads, bias=False):
+        super().__init__()  
+
+        self.multi_head_attention = MultiHeadAttention(
+            dim_in=dim_in,
+            dim_out=dim_out,
+            num_heads=num_heads,
+            context_length=context_length,
+            bias=bias
+        )   
+
+        self.feed_forward = FeedForward(
+            embedding_dim=dim_in,
+            bias=bias
+        )
+        self.norm1 = LayerNorm(embedding_dim=dim_in)
+        self.norm2 = LayerNorm(embedding_dim=dim_in)
+
+    def forward(self, x):
+        residual_connection_attention = x
+        norm1 = self.norm1(x)
+        attention_masked = self.multi_head_attention(norm1)
+        add1 = attention_masked + residual_connection_attention
+
+        residual_connetion_forward = add1
+        norm2 = self.norm2(add1)
+        forward = self.feed_forward(norm2)
+        add2 = forward + residual_connetion_forward
+
+        return add2
 
 
 class GPT2ModelGQA(torch.nn.Module):
@@ -180,6 +261,55 @@ class GPT2ModelGQA(torch.nn.Module):
             bias=config["bias"]
         )
 
+
+    def forward(self, x):
+        batch_size, context_length = x.shape
+        tok_emb = self.embeddings(x)
+        pos_emb = self.pos_embeddings(
+            torch.arange(context_length, device=self.device)
+        )
+        input_emb = tok_emb + pos_emb
+
+        result_transformer_blocks = self.transformer_blocks(input_emb)
+        norm = self.final_norm(result_transformer_blocks)
+        logits = self.out_head(norm)
+
+        return logits
+    
+class GPT2ModelMHA(torch.nn.Module):
+    def __init__(self, config, device):
+        super().__init__()
+        self.device = device
+
+        self.embeddings = torch.nn.Embedding(
+            num_embeddings=config["vocab_size"],
+            embedding_dim=config["embedding_dim"]
+        )
+        self.pos_embeddings = torch.nn.Embedding(
+            num_embeddings=config["context_length"],
+            embedding_dim=config["embedding_dim"]
+        )
+
+        self.transformer_blocks = torch.nn.Sequential(*[
+            TransformerBlockMHA(
+                context_length=config["context_length"],
+                dim_in=config["embedding_dim"],
+                dim_out=config["embedding_dim"],
+                num_heads=config["num_heads"],
+                bias=config["bias"]
+            )
+            for _ in range(config["num_layers"])
+        ])
+
+        self.final_norm = LayerNorm(
+            embedding_dim=config["embedding_dim"],
+            epsilon=1e-5
+        )
+        self.out_head = torch.nn.Linear(
+            config["embedding_dim"],
+            config["vocab_size"],
+            bias=config["bias"]
+        )
 
     def forward(self, x):
         batch_size, context_length = x.shape


### PR DESCRIPTION
# Adicionando baseline com Multi-Head Attention
Este PR introduz uma nova arquitetura baseada em **Multi-Head Attention (MHA)** como baseline para comparação com o modelo original `GPT2ModelGQA`.

## Alterações principais

- Criação da classe `MultiHeadAttention` com atenção causal e projeção final.
- Implementação do bloco `TransformerBlockMHA` com normalização, residual e feedforward.
- Adição do modelo `GPT2ModelMHA`, compatível com a estrutura de embeddings e posição do GPT-2.
- Atualização do `__init__.py` para expor o novo modelo.